### PR TITLE
Work with capybara 2+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,8 @@ source 'https://rubygems.org'
 gem 'roda'
 gem 'tilt'
 gem 'erubis'
+
+group :development, :test do
+  gem 'rspec', '>=2'
+  gem 'capybara', '>=2'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+    diff-lcs (1.2.4)
     erubis (2.7.0)
-    rack (1.4.5)
-    roda (1.1.0)
+    mime-types (2.4.3)
+    nokogiri (1.6.3.1)
+    rack (1.6.0)
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    roda (2.1.0)
       rack
-    tilt (1.4.1)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    tilt (2.0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara (>= 2)
   erubis
   roda
+  rspec (>= 2)
   tilt

--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -33,7 +33,7 @@ end
 describe "AlienistViewer" do
   it "should allow navigating the memory dump" do 
     visit('/')
-    find('title').text.should == "AlienistViewer"
+    page.should have_title('AlienistViewer')
     click_link 'String'
     click_link '"Tom"'
     click_link 'String'


### PR DESCRIPTION
Previously, the specs targeted capybara 1, but that wasn't noted
anywhere.  This adds capybara and rspec to the Gemfile in the
development and test groups.
